### PR TITLE
Fixing MemCachier

### DIFF
--- a/memcacheify.py
+++ b/memcacheify.py
@@ -43,6 +43,9 @@ def memcacheify():
             'TIMEOUT': 500,
         }
     elif all((environ.get(e, '') for e in MEMCACHIER_ENV_VARS)):
+        environ['MEMCACHE_SERVERS'] = environ.get('MEMCACHIER_SERVERS', '')
+        environ['MEMCACHE_USERNAME'] = environ.get('MEMCACHIER_USERNAME', '')
+        environ['MEMCACHE_PASSWORD'] = environ.get('MEMCACHIER_PASSWORD', '')
         caches['default'] = {
             'BACKEND': 'django_pylibmc.memcached.PyLibMCCache',
             'BINARY': True,
@@ -51,9 +54,7 @@ def memcacheify():
                 'ketama': True,
                 'tcp_nodelay': True,
             },
-            'PASSWORD': environ.get('MEMCACHIER_PASSWORD'),
             'TIMEOUT': 500,
-            'USERNAME': environ.get('MEMCACHIER_USERNAME'),
         }
     else:
         caches['default'] = {


### PR DESCRIPTION
PyLibMCCache looks at the environment for a username and password,
not at the USERNAME and PASSWORD options.  Hence, the environment
needs to be modified for MemCachier to work.
