### PR TITLE
Specify that pylibmc requirement has to be in root

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ CACHES = memcacheify()
 
 Next, edit your ``requirements.txt`` file (which Heroku reads) and add
 ``pylibmc==1.2.3`` to the bottom of the file. This is required for Heroku to
-detect the necessary C dependencies and 'bootstrap' your application.
+detect the necessary C dependencies and 'bootstrap' your application. This requirement
+has to be in the root ``requirements.txt`` file, not in any imported requirements.
+([Solution from Stack Overflow](http://stackoverflow.com/questions/11507639/memcached-on-heroku-w-django-cant-install-pylibmc-memcacheify/11587142#11587142))
 
 Assuming you have a memcache server available to your application on Heroku, it
 will instantly be available. If you have no memcache addon provisioned for your


### PR DESCRIPTION
When trying to add `pylibmc` as a requirement, I was getting a long error message from Heroku, 
ending with `error: command 'gcc' failed with exit status 1`. Thankfully I found the solution on StackOverflow
(http://stackoverflow.com/questions/11507639/memcached-on-heroku-w-django-cant-install-pylibmc-memcacheify/11587142#11587142)
