### PR TITLE
Remove Python 2.5 Testing Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.5"
   - "2.6"
   - "2.7"
 install:


### PR DESCRIPTION
`from __future__ import unicode_literals` will fail in 2.5, so the test will not pass.

https://travis-ci.org/rdegges/django-heroku-memcacheify/jobs/5190777#L104
