### PR TITLE
Update dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     include_package_data = True,
 
     # Package dependencies:
-    install_requires = ['Django>=1.2', 'django-pylibmc-sasl==0.2.4', 'pylibmc==1.2.3'],
+    install_requires = ['django-pylibmc==0.5.0'],
 
     # Metadata for PyPI:
     author = 'Randall Degges',


### PR DESCRIPTION
django-pylibmc [backported](https://github.com/jbalogh/django-pylibmc/commit/ec45a179577299cab5d1632628afb18710e38bb9) all of the django-pylibmc-sasl and the latter is outdated and unmaintained.
django-pylibmc depends on Django and pylibmc, thus there's no need to list them explicitly.
