### PR TITLE
Update django-pylibmc dependency to >=0.6.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     include_package_data = True,
 
     # Package dependencies:
-    install_requires = ['django-pylibmc==0.5.0'],
+    install_requires = ['django-pylibmc>=0.6.1'],
 
     # Metadata for PyPI:
     author = 'Randall Degges',


### PR DESCRIPTION
As a bonus, django-pylibmc 0.5.0+ supports Python 3, for which testing will be enabled in another PR.

I've switched to using greater than, since the Python packaging guidelines say it's not best practice to use `install_requires` to pin dependencies to specific versions:
http://python-packaging-user-guide.readthedocs.org/en/latest/requirements/#install-requires