### PR TITLE
Officially support Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
 install:
   - python setup.py develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.5"
 install:
   - python setup.py develop
   - pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ OK
 
 ## Changelog
 
+v1.0.0: Not yet released
+
+    - Update django-pylibmc dependency to >=0.6.1.
+    - Officially support Python 3.5.
+    - Stop testing on Python 2.6.
+
 v0.8: 11-12-2014
 
     - Adding support for memcachedcloud!

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
 
     # Basic package information:
     name = 'django-heroku-memcacheify',
-    version = '0.8',
+    version = '1.0.0',
     py_modules = ('memcacheify',),
 
     # Packaging options:

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,13 @@ setup(
     license = 'UNLICENSE',
     url = 'https://github.com/rdegges/django-heroku-memcacheify',
     keywords = 'django heroku cloud cache memcache memcached awesome epic',
+    classifiers=[
+        'Framework :: Django',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+    ],
     description = 'Automatic Django memcached configuration on Heroku.',
     long_description = open(normpath(join(dirname(abspath(__file__)),
         'README.md'))).read()


### PR DESCRIPTION
* Stop testing on Python 2.6 - since Heroku users have no excuse to be using the unsupported (and insecure) Python 2.6.
* Test under Python 3.5 on Travis and add PyPI compatibility classifiers. Now that #21 has updated the dependency on django-pylibmc to >=0.6.1, it's compatible with Python 3 (they've already enabled testing for it), so django-heroku-memcacheify can officially support Python 3.x too.
* Bump version to 1.0.0 - since this package is mature enough to be a v1 now :-) I've also switched to semver version numbering, for consistency with other Django related packages.