### PR TITLE
README: Update the pylibmc requirements.txt instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,9 @@ from memcacheify import memcacheify
 CACHES = memcacheify()
 ```
 
-Next, edit your ``requirements.txt`` file (which Heroku reads) and add
-``pylibmc==1.2.3`` to the bottom of the file. This is required for Heroku to
-detect the necessary C dependencies and 'bootstrap' your application. This requirement
-has to be in the root ``requirements.txt`` file, not in any imported requirements.
-([Solution from Stack Overflow](http://stackoverflow.com/questions/11507639/memcached-on-heroku-w-django-cant-install-pylibmc-memcacheify/11587142#11587142))
+Next, ensure pylibmc is present in your ``requirements.txt`` file (or one
+included from it), so the Heroku Python buildpack will detect the necessary
+C dependencies and 'bootstrap' your application.
 
 Assuming you have a memcache server available to your application on Heroku, it
 will instantly be available. If you have no memcache addon provisioned for your


### PR DESCRIPTION
pylibmc no longer has to be in the root requirements.txt file, since the Python buildpack now uses pip-grep (rather than regex) to determine whether pylibmc is in the requirements files:
https://github.com/heroku/heroku-buildpack-python/blob/v75/bin/steps/pylibmc#L22

This has been fixed since v43, which was released August 2014:
https://github.com/heroku/heroku-buildpack-python/commit/47c40ce086ee10287c28719fde3647f152a16b35

The Heroku memcachier docs haven't yet been updated to reflect this, however I have submitted a request for it to be corrected too:
https://devcenter.heroku.com/articles/memcachier#django