### PR TITLE
Fix PyPI README.MD showing problem.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     ],
     description='Automatic Django memcached configuration on Heroku.',
     long_description=open(normpath(join(dirname(abspath(__file__)),
-                                        'README.md'))).read()
+                                        'README.md'))).read(),
+    long_description_content_type='text/markdown'
 
 )


### PR DESCRIPTION
There is a problem in the project's pypi page. To fix this I added the following line in the setup.py file:
```python
long_description_content_type='text/markdown'
```